### PR TITLE
Check whether TIFF fields are defined, use defaults where it makes sense

### DIFF
--- a/0_GEN/ImageIO.cpp
+++ b/0_GEN/ImageIO.cpp
@@ -188,7 +188,7 @@ static void Raster8FromTif16Bit(
 	uint16			fmt;
 
 // Check for signed data if 16-bit
-	TIFFGetField( tif, TIFFTAG_SAMPLEFORMAT, &fmt );
+	TIFFGetFieldDefaulted( tif, TIFFTAG_SAMPLEFORMAT, &fmt );
 
 // Read encoded strips
 	raw = (uint16*)malloc( npixels * sizeof(uint16) );
@@ -385,6 +385,7 @@ uint8* Raster8FromTif(
 	uint8*	raster;
 	size_t	npixels;
 	uint16	bps, spp;
+	int ret;
 
 	fprintf( flog, "Raster8FromTif: Opening [%s].\n", name );
 
@@ -405,10 +406,20 @@ TIFFSetWarningHandler( oldEH );
 		exit( 42 );
 	}
 
-	TIFFGetField( tif, TIFFTAG_IMAGEWIDTH, &w );
-	TIFFGetField( tif, TIFFTAG_IMAGELENGTH, &h );
-	TIFFGetField( tif, TIFFTAG_BITSPERSAMPLE, &bps );
-	TIFFGetField( tif, TIFFTAG_SAMPLESPERPIXEL, &spp );
+	ret = TIFFGetField( tif, TIFFTAG_IMAGEWIDTH, &w );
+	if( !ret ) {
+		fprintf( flog,
+		"Raster8FromTif: Image width undefined.\n", name);
+		exit( 42 );
+	}
+	ret = TIFFGetField( tif, TIFFTAG_IMAGELENGTH, &h );
+	if( !ret ) {
+		fprintf( flog,
+		"Raster8FromTif: Image height undefined.\n", name);
+		exit( 42 );
+	}
+	TIFFGetFieldDefaulted( tif, TIFFTAG_BITSPERSAMPLE, &bps );
+	TIFFGetFieldDefaulted( tif, TIFFTAG_SAMPLESPERPIXEL, &spp );
 	npixels = w * h;
 
 	fprintf( flog,
@@ -470,6 +481,7 @@ uint16* Raster16FromTif16(
 	uint16*	raster;
 	size_t	npixels;
 	uint16	bps, spp, fmt;
+	int ret;
 
 #if GENEMEYERSTIFF
 // suppress exotic field warnings
@@ -488,11 +500,21 @@ TIFFSetWarningHandler( oldEH );
 		exit( 42 );
 	}
 
-	TIFFGetField( tif, TIFFTAG_IMAGEWIDTH, &w );
-	TIFFGetField( tif, TIFFTAG_IMAGELENGTH, &h );
-	TIFFGetField( tif, TIFFTAG_BITSPERSAMPLE, &bps );
-	TIFFGetField( tif, TIFFTAG_SAMPLESPERPIXEL, &spp );
-	TIFFGetField( tif, TIFFTAG_SAMPLEFORMAT, &fmt );
+	ret = TIFFGetField( tif, TIFFTAG_IMAGEWIDTH, &w );
+	if( !ret ) {
+		fprintf( flog,
+		"Raster8FromTif: Image width undefined.\n", name);
+		exit( 42 );
+	}
+	ret = TIFFGetField( tif, TIFFTAG_IMAGELENGTH, &h );
+	if( !ret ) {
+		fprintf( flog,
+		"Raster8FromTif: Image height undefined.\n", name);
+		exit( 42 );
+	}
+	TIFFGetFieldDefaulted( tif, TIFFTAG_BITSPERSAMPLE, &bps );
+	TIFFGetFieldDefaulted( tif, TIFFTAG_SAMPLESPERPIXEL, &spp );
+	TIFFGetFieldDefaulted( tif, TIFFTAG_SAMPLEFORMAT, &fmt );
 	npixels = w * h;
 
 	fprintf( flog,

--- a/0_GEN/ImageIO.cpp
+++ b/0_GEN/ImageIO.cpp
@@ -9,6 +9,7 @@
 #include	"tiffio.h"
 
 #include	<limits.h>
+#include	<string.h>
 
 
 /* --------------------------------------------------------------- */

--- a/0_GEN/LinEqu.cpp
+++ b/0_GEN/LinEqu.cpp
@@ -8,6 +8,7 @@
 #include	"Memory.h"
 
 #include	<string.h>
+#include	<unistd.h>
 
 
 /* --------------------------------------------------------------- */

--- a/1_Ptestx/ptestx.cpp
+++ b/1_Ptestx/ptestx.cpp
@@ -34,6 +34,7 @@
 #include	"PipeFiles.h"
 
 #include	<string.h>
+#include	<unistd.h>
 
 
 /* --------------------------------------------------------------- */


### PR DESCRIPTION
In ImageIO.cpp, the return values for TIFFGetField are not checked, which means that if the TIFF field does not exist in the input image file, the value for that field used in the code will be uninitialized (TiffGetField will return 0 in that case: http://www.remotesensing.org/libtiff/man/TIFFGetField.3tiff.html). For me, this caused an issue where SamplesPerPixel was reported as some random value, but that TIFF field has a default of 1 when it is not explicitly defined (http://partners.adobe.com/public/developer/en/tiff/TIFF6.pdf).