### PR TITLE
made docker compatible build image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+Dockerfile

--- a/00_DOC/install_and_build.md
+++ b/00_DOC/install_and_build.md
@@ -161,7 +161,7 @@ _fin_
 ### Docker build instructions
 
 ```
-docker build ($USER)\alignment_projects .
+docker build -t $(USER)\alignment_projects .
 ```
 
 then you should have an ubuntu image with MKL installed and compiled binaries at \usr\local\bin

--- a/00_DOC/install_and_build.md
+++ b/00_DOC/install_and_build.md
@@ -158,5 +158,11 @@ Scripts generally use bash shell (.sh), but I choose to name my files (.sht) for
 
 _fin_
 
+### Docker build instructions
 
+```
+docker build ($USER)\alignment_projects .
+```
+
+then you should have an ubuntu image with MKL installed and compiled binaries at \usr\local\bin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,48 @@
+from ubuntu:16.04 as BUILD
+RUN apt-get update && apt-get -y install build-essential \
+ libopenmpi-dev \
+ libtiff-dev \
+ libpng-dev \
+ zlib1g-dev \
+ libtinyxml-dev \
+ gcc \
+ g++ \
+ gfortran \
+ wget \
+ cpio
+RUN DEBIAN_FRONTEND=noninteractive && \
+  cd /tmp && \
+  wget -q http://registrationcenter-download.intel.com/akdlm/irc_nas/tec/12414/l_mkl_2018.1.163.tgz && \
+  tar -xzf l_mkl_2018.1.163.tgz && \
+  cd l_mkl_2018.1.163 && \
+  sed -i 's/ACCEPT_EULA=decline/ACCEPT_EULA=accept/g' silent.cfg && \
+  sed -i 's/ARCH_SELECTED=ALL/ARCH_SELECTED=INTEL64/g' silent.cfg && \
+#  sed -i 's/COMPONENTS=DEFAULTS/COMPONENTS=;intel-comp-l-all-vars__noarch;intel-openmp-l-all__x86_64;intel-openmp-l-ps-libs__x86_64;intel-openmp-l-ps-libs-jp__x86_64;intel-tbb-libs__noarch;intel-mkl-common__noarch;intel-mkl-sta-common__noarch;intel-mkl__x86_64;intel-mkl-rt__x86_64;intel-mkl-ps-rt-jp__x86_64;intel-mkl-doc__noarch;intel-mkl-ps-doc__noarch;intel-mkl-ps-doc-jp__noarch;intel-mkl-gnu__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-ps-common__noarch;intel-mkl-ps-common-jp__noarch;intel-mkl-ps-common-64bit__x86_64;intel-mkl-common-c__noarch;intel-mkl-common-c-64bit__x86_64;intel-mkl-ps-common-c__noarch;intel-mkl-doc-c__noarch;intel-mkl-ps-doc-c-jp__noarch;intel-mkl-ps-ss-tbb__x86_64;intel-mkl-ps-ss-tbb-rt__x86_64;intel-mkl-gnu-c__x86_64;intel-mkl-ps-common-f__noarch;intel-mkl-ps-common-f-64bit__x86_64;intel-mkl-ps-doc-f__noarch;intel-mkl-ps-doc-f-jp__noarch;intel-mkl-ps-gnu-f-rt__x86_64;intel-mkl-ps-gnu-f__x86_64;intel-mkl-ps-f95-common__noarch;intel-mkl-ps-f__x86_64;intel-mkl-psxe__noarch;intel-psxe-common__noarch;intel-psxe-common-doc__noarch;intel-compxe-pset/g' silent.cfg && \
+  sed -i 's/COMPONENTS=DEFAULTS/COMPONENTS=;intel-comp-l-all-vars__noarch;intel-comp-nomcu-vars__noarch;intel-openmp__x86_64;intel-tbb-libs__x86_64;intel-mkl-common__noarch;intel-mkl-installer-license__noarch;intel-mkl-core__x86_64;intel-mkl-core-rt__x86_64;intel-mkl-doc__noarch;intel-mkl-doc-ps__noarch;intel-mkl-gnu__x86_64;intel-mkl-gnu-rt__x86_64;intel-mkl-common-ps__noarch;intel-mkl-core-ps__x86_64;intel-mkl-common-c__noarch;intel-mkl-core-c__x86_64;intel-mkl-common-c-ps__noarch;intel-mkl-tbb__x86_64;intel-mkl-tbb-rt__x86_64;intel-mkl-gnu-c__x86_64;intel-mkl-common-f__noarch;intel-mkl-core-f__x86_64;intel-mkl-gnu-f-rt__x86_64;intel-mkl-gnu-f__x86_64;intel-mkl-f95-common__noarch;intel-mkl-f__x86_64;intel-mkl-psxe__noarch;intel-psxe-common__noarch;intel-psxe-common-doc__noarch;intel-compxe-pset/g' silent.cfg && \
+  ./install.sh -s silent.cfg && \
+  cd .. && rm -rf * && \
+  rm -rf /opt/intel/.*.log /opt/intel/compilers_and_libraries_2018.1.163/licensing && \
+  echo "/opt/intel/mkl/lib/intel64" >> /etc/ld.so.conf.d/intel.conf && \
+  ldconfig && \
+  echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc
+COPY . /code/Alignment_Projects
+COPY docker/ /code/Alignment_Projects
+COPY docker/00_ENV/aln_makefile_std_defs /code/aln_makefile_std_defs
+RUN mkdir -p /code/Alignment_Projects/bin
+ENV FLAGS_MKL=-I/opt/intel/mkl/include
+ENV ALN_LOCAL_MAKE_PATH=/code
+ENV MRC_TRIM=12
+ENV PATH=$PATH:$HOME/bin:/code/Alignment_Projects/bin
+ENV MKL_NUM_THREADS=1
+ARG FLAGS_MKL=-I/opt/intel/mkl/include
+ARG ALN_LOCAL_MAKE_PATH=/code
+ARG MRC_TRIM=12
+ARG MKL_NUM_THREADS=1
+WORKDIR /code/Alignment_Projects/00_ENV
+RUN /bin/bash -c "source /opt/intel/mkl/bin/mklvars.sh intel64;make"
+WORKDIR /code/Alignment_Projects/bin
+
+FROM ubuntu:16.04
+COPY --from=BUILD /opt/intel /opt/intel
+RUN echo "source /opt/intel/mkl/bin/mklvars.sh intel64" >> /etc/bash.bashrc
+COPY --from=BUILD /code/Alignment_Projects/bin /usr/local/bin

--- a/docker/00_ENV/aln_makefile_std_defs
+++ b/docker/00_ENV/aln_makefile_std_defs
@@ -1,0 +1,245 @@
+
+
+# ==========================
+# ==========================
+# Standard build definitions
+# ==========================
+# ==========================
+
+
+# =======================
+# text processing helpers
+# =======================
+
+empty :=
+comma := ,
+space := $(empty) $(empty)
+
+# =================
+# source code paths
+# =================
+
+# EDIT THIS--FORREST
+# My git alignment repo lives here:
+
+PATH_SRCCODE := /code/Alignment_Projects
+
+# DON'T EDIT THIS--
+# Subdirs within my git repo:
+
+PATH_GEN := $(PATH_SRCCODE)/0_GEN
+PATH_UTL := $(PATH_SRCCODE)/0_UTL
+PATH_XML := $(PATH_SRCCODE)/0_XML
+PATH_BK  := $(PATH_SRCCODE)/0_BK
+
+# DON'T EDIT THIS--
+# Archives built by repo:
+
+STATICLIBS_GEN := $(PATH_GEN)/genlib.a
+STATICLIBS_UTL := $(PATH_UTL)/utllib.a
+STATICLIBS_XML := $(PATH_XML)/xmllib.a
+
+# ==================
+# output binary path
+# ==================
+
+# EDIT THIS--
+# I want my alignment output binaries to live here:
+
+PATH_OUT := /code/Alignment_Projects/bin
+
+# =======================
+# 3rd party library paths
+# =======================
+
+# EDIT THIS IF NOT AT JANELIA FARM--
+# We unconditionally need libraries {libtiff, libpng, libz},
+# so you MAY have to install those yourself. We have some
+# docs about that in Alignment_Projects/00_Libraries.
+#
+# Further, we need the paths for their include files and their
+# archive files. At Janelia Farm, these are preinstalled in a
+# shared public directory; our definitions look like this:
+
+PATH_USR_LIB := /usr/lib/x86_64-linux-gnu
+STATICLIBS_TIF := $(PATH_USR_LIB)/libtiff.a
+STATICLIBS_PNG := $(PATH_USR_LIB)/libpng.a
+STATICLIBS_ZLB := $(PATH_USR_LIB)/libz.a
+STATICLIBS_JBIG := $(PATH_USR_LIB)/libjbig.a
+STATICLIBS_LZMA := $(PATH_USR_LIB)/liblzma.a
+STATICLIBS_JPEG := $(PATH_USR_LIB)/libjpeg.a
+
+# ===================
+# FFT library support
+# ===================
+
+# EDIT THIS IF NOT AT JANELIA FARM--
+# You need one and only one of the following two FFT packages:
+# {fftw3, intel_MKL}. The MKL library is preferred because the
+# code is fully reentrant, so multithreaded application code
+# can forego serialization and run faster.
+#
+# If using MKL, you don't need to define a real 'PATH_FFT_INC'
+# because your bash.rc file will likely run a script to set
+# environment variables like this:
+#
+# if [ -f /usr/local/INTEL2016.sh ]; then
+#      . /usr/local/INTEL2016.sh
+# fi
+#
+# The following lets us easily select either package. Note that
+# 'FLAGS_MKL' controls compiler switch 'ALN_USE_MKL' which tells
+# the code which API to call.
+
+MKL_AVAILABLE := 1
+
+ifeq ($(MKL_AVAILABLE), 1)
+
+PATH_FFT_INC   := " "
+STATICLIBS_FFT := -lmkl_intel_lp64 -lmkl_sequential -lmkl_core
+FLAGS_MKL      := -DALN_USE_MKL
+
+else
+
+PATH_FFT       := $(PATH_PUBLIC)/FFT
+PATH_FFT_INC   := $(PATH_FFT)/include
+PATH_FFT_LIB   := $(PATH_FFT)/lib
+STATICLIBS_FFT := $(PATH_FFT_LIB)/libfftw3.a
+FLAGS_MKL      :=
+
+endif
+
+# =============
+# include paths
+# =============
+
+INCLUDES_STD := -I$(PATH_TIF_INC) -I$(PATH_PNG_INC) -I$(PATH_GEN) -I$(PATH_UTL) -I$(PATH_XML) -I$(PATH_FFT_INC)
+
+# ==================
+# standard libraries
+# ==================
+
+# -l option searches usual hierarchy for static library, e.g.,
+# -lXXX searches for 'libXXX.a'. -L option adds dirs to the
+# search hierarchy for -l option.
+
+# jpeg:		jpeg image format
+# m:		math
+# c:		c runtime
+# rt:		posix libraries (e.g. semaphore support)
+# curl:		libcurl parser for Janelia command lines
+
+USING_CURL := 0
+
+ifeq ($(USING_CURL), 1)
+
+OTHERLIBS_STD := -pthread -lm -lc -lrt -lcurl 
+FLAGS_URL     := -DUSE_CURL
+
+else
+
+OTHERLIBS_STD := -pthread -lm -lc -lrt 
+FLAGS_URL     :=
+
+endif
+
+# ==============================
+# combine all standard libraries
+# ==============================
+
+# IMPORTANT:
+# Libraries must be listed such that those with greater dependency are first
+# and the more independent libraries are toward the tail of the list.
+
+LINKS_STD :=\
+ $(STATICLIBS_GEN)\
+ $(STATICLIBS_UTL)\
+ $(STATICLIBS_XML)\
+ $(STATICLIBS_TIF)\
+ $(STATICLIBS_PNG)\
+ $(STATICLIBS_ZLB)\
+ $(STATICLIBS_FFT)\
+ $(STATICLIBS_JBIG)\
+ $(STATICLIBS_LZMA)\
+ $(STATICLIBS_JPEG)\
+ $(OTHERLIBS_STD)
+
+# ===========
+# g++ options
+# ===========
+
+CC := g++
+
+# -DXXX:				define symbol XXX
+# TIXML_USE_STL:		tinyxml uses std library
+# O3:					optimizer level 3 (max)
+
+# The following optimizations allow a developer to make classes with methods that
+# are used in some applications and not others. As long as the extra functionality
+# is never referenced in a given application, it will be stripped out.
+
+# fdata-sections:		separate data symbols (for linker removal)
+# ffunction-sections:	separate func symbols (for linker removal)
+# -Wl,XXX:				XXX is a linker option
+# --gc-sections:		garbage-collect unreferenced input sections
+# --strip-all:			omit symbols from output (makes smaller exe)
+
+CFLAGS := -pthread $(FLAGS_MKL) $(FLAGS_URL) -DTIXML_USE_STL -O3 -fdata-sections -ffunction-sections
+
+LFLAGS := -Wl,--gc-sections -Wl,--strip-all
+
+OUTPUT = -o $(PATH_OUT)/$@
+
+# Enable following lines to debug with gdb or Valgrind
+
+#CFLAGS := -pthread $(FLAGS_MKL) $(FLAGS_URL) -DTIXML_USE_STL -O0 -g
+#LFLAGS :=
+
+# ==============
+# standard rules
+# ==============
+
+# Notes:
+# (1) Place '@' in front of a rule to silence echoing the rule in build log.
+#
+# (2) This include file is usually included at the top of a make file.
+# Hence, the targets defined here will be ahead of targets such as 'all'
+# in the make file that uses this include. The default target when make
+# is run with no named target is usually the first defined and we want
+# that to be 'all' instead of 'CHECK_TINYLIB'. We put a '.' in front
+# of a target name here to exclude it from the default target search.
+
+%.o : %.cpp
+	$(CC) $(CFLAGS) $(INCLUDES_STD) -c $< -o $@
+
+.CHECK_ALL_LIBS : .CHECK_GENLIB .CHECK_UTLLIB .CHECK_TNYLIB
+
+.CHECK_GENLIB :
+	@ (cd $(PATH_GEN) && $(MAKE))
+
+.CHECK_UTLLIB :
+	@ (cd $(PATH_UTL) && $(MAKE))
+
+.CHECK_TNYLIB :
+	@ (cd $(PATH_XML) && $(MAKE))
+
+.PHONY : .CHECK_ALL_LIBS .CHECK_GENLIB .CHECK_UTLLIB .CHECK_TNYLIB
+
+# =================
+# development rules
+# =================
+
+DEV_PATH := $(PATH_OUT)/devtest
+
+DEV_OUTPUT = -o $(DEV_PATH)/$@
+
+.DEV_MKDIR :
+	@ (mkdir -p $(DEV_PATH))
+
+.PHONY : .DEV_MKDIR
+
+# =============================================
+# =============================================
+# =============================================
+
+

--- a/docker/1_LSQw/makefile
+++ b/docker/1_LSQw/makefile
@@ -1,0 +1,39 @@
+
+include $(ALN_LOCAL_MAKE_PATH)/aln_makefile_std_defs
+
+# If Valgrind (run as valgrind --leak-check=yes <mycmdline>)
+#CFLAGS = -g -O0
+#LFLAGS =
+
+# Compile mpi-based apps with CC := mpicxx (gnu), or mpiicpc (intel)
+# and add -mt_mpi switch to LFLAGS
+CC := mpicxx
+#LFLAGS += -mt_mpi
+
+appname = lsqw
+
+files =\
+ lsqw.cpp\
+ ../1_LSQi/lsq_Layers.cpp\
+ lsq_Bounds.cpp\
+ lsq_Dropout.cpp\
+ lsq_Error.cpp\
+ lsq_Globals.cpp\
+ lsq_LoadPoints.cpp\
+ lsq_Magnitude.cpp\
+ lsq_MPI.cpp\
+ lsq_Solve.cpp\
+ lsq_Split.cpp\
+ lsq_Untwist.cpp\
+ lsq_XArray.cpp
+
+objs = ${files:.cpp=.o}
+
+all : $(appname)
+
+clean :
+	rm -f *.o
+
+$(appname) : .CHECK_GENLIB ${objs}
+	$(CC) $(LFLAGS) ${objs} $(LINKS_STD) $(OUTPUT)
+

--- a/docker/2_FFTomos/makefile
+++ b/docker/2_FFTomos/makefile
@@ -1,0 +1,37 @@
+
+include $(ALN_LOCAL_MAKE_PATH)/aln_makefile_std_defs
+
+CFLAGS += -I$(PATH_BK)
+
+appname = fftomos
+
+files =\
+ FFTomos.cpp\
+ CMask.cpp
+
+objs = ${files:.cpp=.o}
+
+bk_files =\
+ BK_BMAP.c\
+ BK_BMAP_CONVERT.c\
+ BK_BMAP_SET.c\
+ BK_BMP.c\
+ BK_GEOM.c\
+ BK_HST.c\
+ BK_MEM.c\
+ BK_RGN.c\
+ BK_SORT.c\
+ BK_SORT_FP32.c\
+ BK_STAT.c\
+ BK_SUM.c
+
+#bk_src = $(PATH_BK)/{$(subst $(space),$(comma),$(bk_files))}
+bk_src = $(foreach file,$(bk_files),$(PATH_BK)/$(file))
+all : $(appname)
+
+clean :
+	rm -f *.o
+
+$(appname) : .CHECK_GENLIB ${objs}
+	$(CC) $(CFLAGS) $(bk_src) $(LFLAGS) ${objs} $(LINKS_STD) $(OUTPUT)
+


### PR DESCRIPTION
I made a dockerfile for your project that compiles... i had to do some reformatting of some of the makefiles to make it work, so i place those in a docker subdirectory had the dockerfile overwrite them.  I wanted to try to figure out how to statically link MKL as well so the binaries could be used outside of a large docker image, but didn't get that working.  Not sure about the MPI stuff here, but it at least compiles and runs the non-mpi based executables. 

